### PR TITLE
added check to determine if same element was selected twice by user

### DIFF
--- a/pyRevitMEP.tab/Modify.panel/ConnectTo.pushbutton/script.py
+++ b/pyRevitMEP.tab/Modify.panel/ConnectTo.pushbutton/script.py
@@ -58,6 +58,11 @@ def connect_to():
             import time
             time.sleep(2)
 
+    # Check if user has selected same element twice to prevent errors and unintended movements
+    if target_element.Id == moved_element.Id:
+        rpw.ui.forms.Alert("Oops, it looks like you've selected the same object twice.", header='Attribute Error')
+        return True
+
     # Get associated unused connectors
     moved_connector = get_connector_closest_to(get_connector_manager(moved_element).UnusedConnectors,
                                                moved_point)


### PR DESCRIPTION
Hi Cyril, I added a check in ConnectTo to return True if the user selects the same element twice (i.e. as target and moved). I was running into errors using ConnectTo whenever I would accidentally select the same element twice and this addition allows more benign behavior.